### PR TITLE
Add ssh providers to Airflow

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Run tests
         # Directory creation step required for testing
         run: |
-          mkdir -p ~/.ssh
           just build
+          just _dc config
           just up
           just test

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,7 +22,9 @@ jobs:
       - uses: actions/checkout@v3
       - uses: extractions/setup-just@v1
       - name: Run tests
+        # Directory creation step required for testing
         run: |
+          mkdir -p ~/.ssh
           just build
           just up
           just test

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -24,7 +24,8 @@ jobs:
       - name: Run tests
         # Directory creation step required for testing
         run: |
+          mkdir -p ~/.ssh
+          chmod -R 666 ~/.ssh
           just build
-          just _dc config
           just up
           just test

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,8 +39,8 @@ ENV AIRFLOW__LOGGING__REMOTE_BASE_LOG_FOLDER=s3://techbloc-airflow-logs
 #    && apt-get autoremove -y \
 #    && rm -rf /var/lib/apt/lists/*
 USER root
-RUN mkdir -p ${DATABASE_DIR} /home/airflow/.ipython/ /opt/airflow/.ssh/ && \
-    chown -R airflow ${DATABASE_DIR} /home/airflow/.ipython/ /opt/airflow/.ssh/
+RUN mkdir -p ${DATABASE_DIR} /home/airflow/.ipython/ /opt/ssh/ && \
+    chown -R airflow ${DATABASE_DIR} /home/airflow/.ipython/ /opt/ssh/
 USER airflow
 
 WORKDIR  ${AIRFLOW_HOME}

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,8 +39,8 @@ ENV AIRFLOW__LOGGING__REMOTE_BASE_LOG_FOLDER=s3://techbloc-airflow-logs
 #    && apt-get autoremove -y \
 #    && rm -rf /var/lib/apt/lists/*
 USER root
-RUN mkdir -p ${DATABASE_DIR} /home/airflow/.ipython/ && \
-    chown -R airflow ${DATABASE_DIR} /home/airflow/.ipython/
+RUN mkdir -p ${DATABASE_DIR} /home/airflow/.ipython/ /opt/airflow/.ssh/ && \
+    chown -R airflow ${DATABASE_DIR} /home/airflow/.ipython/ /opt/airflow/.ssh/
 USER airflow
 
 WORKDIR  ${AIRFLOW_HOME}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -17,7 +17,7 @@ x-airflow-common:
   volumes:
     - ipython:/home/airflow/.ipython:z
     - ./techbloc_airflow:/opt/airflow/techbloc_airflow
-    - ~/.ssh:/opt/airflow/.ssh
+    - ~/.ssh:/opt/ssh/
 
 
 services:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -17,6 +17,7 @@ x-airflow-common:
   volumes:
     - ipython:/home/airflow/.ipython:z
     - ./techbloc_airflow:/opt/airflow/techbloc_airflow
+    - ~/.ssh:/opt/airflow/.ssh
 
 
 services:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -15,7 +15,7 @@ services:
 
   scheduler:
     volumes:
-      - /home/techbloc/.ssh:/opt/airflow/.ssh
+      - /home/techbloc/.ssh:/opt/ssh
 
 volumes:
   caddy_data:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,6 +13,10 @@ services:
       - $PWD/site:/srv
       - caddy_config:/config
 
+  scheduler:
+    volumes:
+      - /home/techbloc/.ssh:/opt/airflow/.ssh
+
 volumes:
   caddy_data:
   caddy_config:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -17,6 +17,10 @@ services:
     volumes:
       - /home/techbloc/.ssh:/opt/ssh
 
+  webserver:
+    volumes:
+      - /home/techbloc/.ssh:/opt/ssh
+
 volumes:
   caddy_data:
   caddy_config:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     image: ghcr.io/orcacollective/techbloc-airflow:${DOCKER_IMAGE_TAG:-latest}
     env_file: .env
     restart: always
+    user: root
     environment:
       # Upgrade the DB on startup
       _AIRFLOW_DB_UPGRADE: "true"
@@ -20,6 +21,7 @@ services:
     image: ghcr.io/orcacollective/techbloc-airflow:${DOCKER_IMAGE_TAG:-latest}
     env_file: .env
     restart: always
+    user: root
     command: webserver
     ports:
       - "${AIRFLOW_PORT}:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     image: ghcr.io/orcacollective/techbloc-airflow:${DOCKER_IMAGE_TAG:-latest}
     env_file: .env
     restart: always
+    # Only necessary for the entrypoint, services run as "airflow"
     user: root
     environment:
       # Upgrade the DB on startup
@@ -21,6 +22,7 @@ services:
     image: ghcr.io/orcacollective/techbloc-airflow:${DOCKER_IMAGE_TAG:-latest}
     env_file: .env
     restart: always
+    # Only necessary for the entrypoint, services run as "airflow"
     user: root
     command: webserver
     ports:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -67,4 +67,7 @@ mkdir -p /home/airflow/.ssh/
 cp /opt/ssh/* /home/airflow/.ssh/
 chown -R airflow /home/airflow/.ssh/
 
+# This script is run as root, but everything hereafter we want to run as
+# the airflow user. This is done so that permissions with the host can be
+# managed appropriately.
 exec runuser -u airflow -- /entrypoint "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -63,7 +63,7 @@ done < <(env | grep "^AIRFLOW_CONN[A-Z_]\+=http.*$")
 
 header "COPYING SSH FILES"
 
-mkdir /home/airflow/.ssh/
+mkdir -p /home/airflow/.ssh/
 cp /opt/airflow/.ssh/* /home/airflow/.ssh/
 chown -R airflow /home/airflow/.ssh/
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -61,4 +61,10 @@ while read -r var_string; do
 # only include airflow connections with http somewhere in the string
 done < <(env | grep "^AIRFLOW_CONN[A-Z_]\+=http.*$")
 
-exec /entrypoint "$@"
+header "COPYING SSH FILES"
+
+mkdir /home/airflow/.ssh/
+cp /opt/airflow/.ssh/* /home/airflow/.ssh/
+chown -R airflow /home/airflow/.ssh/
+
+exec runuser -u airflow -- /entrypoint "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -64,7 +64,7 @@ done < <(env | grep "^AIRFLOW_CONN[A-Z_]\+=http.*$")
 header "COPYING SSH FILES"
 
 mkdir -p /home/airflow/.ssh/
-cp /opt/airflow/.ssh/* /home/airflow/.ssh/
+cp /opt/ssh/* /home/airflow/.ssh/
 chown -R airflow /home/airflow/.ssh/
 
 exec runuser -u airflow -- /entrypoint "$@"

--- a/justfile
+++ b/justfile
@@ -103,8 +103,8 @@ test *pytestargs:
     @just _mount-tests "bash -c \'pytest {{ pytestargs }}\'"
 
 # Open a shell into the webserver container
-shell: up
-    @just _dc exec {{ SERVICE }} /bin/bash
+shell user="airflow": up
+    @just _dc exec -u {{ user }} {{ SERVICE }} /bin/bash
 
 # Launch an IPython REPL using the webserver image
 ipython: _deps

--- a/justfile
+++ b/justfile
@@ -57,6 +57,10 @@ up flags="": dotenv
 down flags="":
     @just _dc down {{ flags }}
 
+# Pull all new images
+pull flags="":
+    @just _dc pull {{ flags }}
+
 # Recreate all volumes and containers from scratch
 recreate: dotenv
     @just down -v
@@ -68,9 +72,8 @@ logs service="": up
 
 # Pull, build, and deploy all services
 deploy:
-    @just down
     -git pull
-    @just build
+    @just pull
     @just up
 
 # Run pre-commit on all files

--- a/requirements_prod.txt
+++ b/requirements_prod.txt
@@ -1,2 +1,2 @@
 # PYTHON=3.10
-apache-airflow[amazon,sqlite,http]==2.4.3
+apache-airflow[amazon,sqlite,http,ssh]==2.4.3


### PR DESCRIPTION
This PR adds the SSH provider for Airflow to the image, along with a number of changes related to permissions management so that Airflow can reference and use the host's ssh config.