### PR TITLE
Mastodon backup rotation & retention DAG

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -32,6 +32,7 @@ AIRFLOW__DATABASE__SQL_ALCHEMY_CONN=sqlite:////opt/airflow/db/airflow.db
 # Remote logging connection ID
 # Replace "access_key" and "secret+key" with the real values. Secret key must be URL-encoded
 AIRFLOW_CONN_AWS_DEFAULT=aws://test_key:test_secret@?region_name=us-east-1&endpoint_url=http://s3:5000
+AIRFLOW_CONN_SPACES_MASTODON=aws://test_key:test_secret@?region_name=us-east-1&endpoint_url=http://s3:5000
 
 # SSH connections
 AIRFLOW_CONN_SSH_MASTODON=ssh://user@service

--- a/techbloc_airflow/dags/constants.py
+++ b/techbloc_airflow/dags/constants.py
@@ -3,3 +3,5 @@ SSH_MONOLITH_CONN_ID = "ssh_monolith"
 
 MATRIX_WEBHOOK_CONN_ID = "matrix_webhook"
 MATRIX_WEBHOOK_API_KEY = "matrix_webhook_api_key"
+
+SPACES_MASTODON_CONN_ID = "spaces_mastodon"

--- a/techbloc_airflow/dags/maintenance/mastodon/backups/rotation.py
+++ b/techbloc_airflow/dags/maintenance/mastodon/backups/rotation.py
@@ -1,0 +1,26 @@
+from typing import NamedTuple
+
+from airflow.decorators import task
+
+
+class RotationPeriod(NamedTuple):
+    name: str
+    count: int
+
+
+@task()
+def get_most_recent_backup(backups: list[str]) -> str:
+    backups = sorted(backups, reverse=True)
+    backups = [backup for backup in backups if not backup.endswith("/")]
+    # Return only the prefix itself
+    return backups[0].split("/")[-1]
+
+
+@task()
+def get_files_to_delete(
+    backups: list[str],
+    count: int,
+) -> list[str]:
+    backups = sorted(backups, reverse=True)
+    backups = [backup for backup in backups if not backup.endswith("/")]
+    return backups[count:]

--- a/techbloc_airflow/dags/maintenance/mastodon/backups/rotation.py
+++ b/techbloc_airflow/dags/maintenance/mastodon/backups/rotation.py
@@ -1,17 +1,12 @@
-from typing import NamedTuple
-
 from airflow.decorators import task
-
-
-class RotationPeriod(NamedTuple):
-    name: str
-    count: int
 
 
 @task()
 def get_most_recent_backup(backups: list[str]) -> str:
     backups = sorted(backups, reverse=True)
     backups = [backup for backup in backups if not backup.endswith("/")]
+    if not backups:
+        raise ValueError("No backups found")
     # Return only the prefix itself
     return backups[0].split("/")[-1]
 

--- a/techbloc_airflow/dags/maintenance/mastodon/backups/rotation_dag.py
+++ b/techbloc_airflow/dags/maintenance/mastodon/backups/rotation_dag.py
@@ -1,0 +1,90 @@
+from datetime import datetime
+
+import constants
+from airflow.decorators import dag
+from airflow.providers.amazon.aws.operators.s3 import (
+    S3CopyObjectOperator,
+    S3DeleteObjectsOperator,
+    S3ListOperator,
+)
+from airflow.utils.task_group import TaskGroup
+from maintenance.mastodon.backups import rotation
+from maintenance.mastodon.backups.rotation import RotationPeriod
+
+
+BUCKET_NAME = "mastadon-backups"
+PERIODS = [
+    RotationPeriod("hourly", 24),
+    RotationPeriod("daily", 7),
+    RotationPeriod("weekly", 4),
+]
+
+
+for period in PERIODS:
+    dag_id = f"mastodon_rotate_backup_{period.name}"
+
+    @dag(
+        dag_id=dag_id,
+        start_date=datetime(2022, 11, 24),
+        catchup=False,
+        schedule=f"@{period.name}",
+        tags=["maintenance", "backups", "mastodon"],
+    )
+    def backup_dag():
+        for service in ["postgres", "redis", "user-media"]:
+            with TaskGroup(group_id=f"rotate_{service}"):
+
+                # Hourly backups are stored in the root of the bucket
+                prefix = (
+                    f"{service}/{period.name}/"
+                    if period.name != "hourly"
+                    else f"{service}/"
+                )
+
+                # While these are defined first in the DAG, they're actually the last
+                # steps. They need to be defined here to be used in the flow below.
+                list_period_keys = S3ListOperator(
+                    task_id=f"list_existing_{period.name}_backups_{service}",
+                    aws_conn_id=constants.SPACES_MASTODON_CONN_ID,
+                    bucket=BUCKET_NAME,
+                    prefix=prefix,
+                )
+
+                get_delete_files = rotation.get_files_to_delete.override(
+                    task_id=f"get_files_to_delete_{service}"
+                )(list_period_keys.output, period.count)
+
+                delete_old_backups = S3DeleteObjectsOperator(
+                    task_id=f"delete_old_backups_{service}",
+                    aws_conn_id=constants.SPACES_MASTODON_CONN_ID,
+                    bucket=BUCKET_NAME,
+                    keys=get_delete_files,
+                )
+
+                list_period_keys >> get_delete_files >> delete_old_backups
+
+                # Hourly backups don't require archiving
+                if period.name != "hourly":
+                    list_keys = S3ListOperator(
+                        task_id=f"list_existing_hourly_backups_{service}",
+                        aws_conn_id=constants.SPACES_MASTODON_CONN_ID,
+                        bucket=BUCKET_NAME,
+                        prefix=f"{service}/",
+                    )
+
+                    most_recent_backup = rotation.get_most_recent_backup.override(
+                        task_id=f"get_most_recent_backup_{service}"
+                    )(list_keys.output)
+
+                    copy_most_recent = S3CopyObjectOperator(
+                        task_id=f"copy_most_recent_backup_{service}",
+                        aws_conn_id=constants.SPACES_MASTODON_CONN_ID,
+                        source_bucket_name=BUCKET_NAME,
+                        dest_bucket_name=BUCKET_NAME,
+                        source_bucket_key=f"{service}/{most_recent_backup}",
+                        dest_bucket_key=f"{service}/{period.name}/{most_recent_backup}",
+                    )
+
+                    most_recent_backup >> copy_most_recent >> list_period_keys
+
+    backup_dag()

--- a/techbloc_airflow/dags/maintenance/mastodon/backups/rotation_dag.py
+++ b/techbloc_airflow/dags/maintenance/mastodon/backups/rotation_dag.py
@@ -12,14 +12,12 @@ from airflow.utils.task_group import TaskGroup
 from maintenance.mastodon.backups import rotation
 
 
-BUCKET_NAME = "mastadon-backups"
-
-
 class RotationPeriod(NamedTuple):
     name: str
     count: int
 
 
+BUCKET_NAME = "mastadon-backups"
 PERIODS = [
     RotationPeriod("hourly", 24),
     RotationPeriod("daily", 7),
@@ -41,7 +39,8 @@ for period in PERIODS:
         for service in ["postgres", "redis", "user-media"]:
             with TaskGroup(group_id=f"rotate_{service}"):
 
-                # Hourly backups are stored in the root of the bucket
+                # Hourly backups are stored in the root of the bucket, whereas backups
+                # by period are stored in a prefix by that period name
                 prefix = (
                     f"{service}/{period.name}/"
                     if period.name != "hourly"

--- a/techbloc_airflow/dags/maintenance/mastodon/backups/rotation_dag.py
+++ b/techbloc_airflow/dags/maintenance/mastodon/backups/rotation_dag.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import NamedTuple
 
 import constants
 from airflow.decorators import dag
@@ -9,10 +10,16 @@ from airflow.providers.amazon.aws.operators.s3 import (
 )
 from airflow.utils.task_group import TaskGroup
 from maintenance.mastodon.backups import rotation
-from maintenance.mastodon.backups.rotation import RotationPeriod
 
 
 BUCKET_NAME = "mastadon-backups"
+
+
+class RotationPeriod(NamedTuple):
+    name: str
+    count: int
+
+
 PERIODS = [
     RotationPeriod("hourly", 24),
     RotationPeriod("daily", 7),

--- a/tests/dags/maintenance/mastodon/backups/test_rotation.py
+++ b/tests/dags/maintenance/mastodon/backups/test_rotation.py
@@ -1,0 +1,76 @@
+import pytest
+from maintenance.mastodon.backups import rotation
+
+
+BACKUP_LIST = [
+    "postgres/daily/",
+    "postgres/weekly/",
+    "postgres/",
+    "postgres/2022-11-25_19-00-01_backup.dump",
+    "postgres/2022-11-25_20-00-01_backup.dump",
+    "postgres/2022-11-25_21-00-01_backup.dump",
+    "postgres/2022-11-25_22-00-01_backup.dump",
+    "postgres/2022-11-25_23-00-01_backup.dump",
+    "postgres/2022-11-26_00-00-01_backup.dump",
+    "postgres/2022-11-26_01-00-01_backup.dump",
+    "postgres/2022-11-26_02-00-01_backup.dump",
+    "postgres/2022-11-26_03-00-01_backup.dump",
+    "postgres/2022-11-26_04-00-01_backup.dump",
+    "postgres/2022-11-26_05-00-01_backup.dump",
+    "postgres/2022-11-26_06-00-01_backup.dump",
+    "postgres/2022-11-26_07-00-01_backup.dump",
+    "postgres/2022-11-26_08-00-01_backup.dump",
+    "postgres/2022-11-26_09-00-01_backup.dump",
+    "postgres/2022-11-26_10-00-01_backup.dump",
+    "postgres/2022-11-26_11-00-01_backup.dump",
+    "postgres/2022-11-26_12-00-01_backup.dump",
+    "postgres/2022-11-26_13-00-01_backup.dump",
+    "postgres/2022-11-26_14-00-01_backup.dump",
+    "postgres/2022-11-26_15-00-01_backup.dump",
+    "postgres/2022-11-26_16-00-01_backup.dump",
+    "postgres/2022-11-26_17-00-01_backup.dump",
+]
+
+
+@pytest.mark.parametrize(
+    "backups, expected",
+    [
+        # Full backup list
+        (BACKUP_LIST, "2022-11-26_17-00-01_backup.dump"),
+        # Empty list
+        pytest.param(
+            [],
+            None,
+            marks=pytest.mark.raises(exception=ValueError),
+        ),
+        # Only directories
+        pytest.param(
+            BACKUP_LIST[:3],
+            None,
+            marks=pytest.mark.raises(exception=ValueError),
+        ),
+    ],
+)
+def test_get_most_recent_backup(backups, expected):
+    actual = rotation.get_most_recent_backup.function(backups)
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "backups, count, expected",
+    [
+        # Keep one
+        (BACKUP_LIST, 1, BACKUP_LIST[3:-1]),
+        # Keep several, should be last few
+        (BACKUP_LIST, 5, BACKUP_LIST[3:-5]),
+        # Keep all
+        (BACKUP_LIST, len(BACKUP_LIST), []),
+        # Emtpy input list
+        ([], 10, []),
+        # Don't keep any
+        (BACKUP_LIST, 0, BACKUP_LIST[3:]),
+    ],
+)
+def test_get_files_to_delete(backups, count, expected):
+    actual = rotation.get_files_to_delete.function(backups, count)
+    assert set(actual) == set(expected)


### PR DESCRIPTION
This PR adds DAGs which help manage our Mastodon backups.

The backups get sent to S3 prefixes based on the service, but beyond that they all get dumped in the same folder. The backups all occur hourly so we don't have an existing delimiter between hourly/daily/weekly backups. For hourly backups, we just want to keep 24 of them. For daily and weekly, the DAGs get scheduled as `@daily` and `@weekly` respectively and copy the most recent into appropriate prefixes. Then the retention step is run on those prefixes after the copy is complete. We want to have 7 daily backups retained and 4 weekly ones.

**Hourly**
![image](https://user-images.githubusercontent.com/10214785/204119957-20ec6115-888f-4eda-9c83-59aadd18b722.png)

**Daily**
![image](https://user-images.githubusercontent.com/10214785/204119964-46b8f306-c382-47a3-b6e2-01a46362bfab.png)
