### PR TITLE
Add Matrix on failure callback

### DIFF
--- a/techbloc_airflow/dags/common/dag_utils.py
+++ b/techbloc_airflow/dags/common/dag_utils.py
@@ -1,0 +1,15 @@
+from datetime import timedelta
+
+from common import matrix
+
+
+DEFAULT_DAG_ARGS = {
+    "catchup": False,
+    "owner": "techbloc",
+    "depends_on_past": False,
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retry_delay": timedelta(minutes=5),
+    "execution_timeout": timedelta(hours=1),
+    "on_failure_callback": matrix.on_failure_callback,
+}

--- a/techbloc_airflow/dags/common/matrix.py
+++ b/techbloc_airflow/dags/common/matrix.py
@@ -1,0 +1,26 @@
+import json
+
+import constants
+from airflow.models import Variable
+from airflow.providers.http.hooks.http import HttpHook
+
+
+def send_message(
+    text: str,
+    conn_id: str = constants.MATRIX_WEBHOOK_CONN_ID,
+    api_key: str = None,
+) -> None:
+    """
+    Send a message to Matrix using a connection ID and API key.
+    """
+    hook = HttpHook(method="POST", http_conn_id=conn_id)
+    environment = Variable.get("ENVIRONMENT", default_var="dev")
+    api_key = api_key or Variable.get(constants.MATRIX_WEBHOOK_API_KEY)
+    hook.run(
+        data=json.dumps(
+            {
+                "key": api_key,
+                "body": f"**[Airflow {environment}]**\n {text}",
+            }
+        )
+    )

--- a/techbloc_airflow/dags/common/matrix.py
+++ b/techbloc_airflow/dags/common/matrix.py
@@ -9,9 +9,6 @@ from airflow.providers.http.hooks.http import HttpHook
 
 log = logging.getLogger(__name__)
 
-# TODO: Tests
-# TODO: Convert existing DAG to use func
-
 
 def should_send_message(
     environment: str,

--- a/techbloc_airflow/dags/constants.py
+++ b/techbloc_airflow/dags/constants.py
@@ -1,22 +1,5 @@
-from datetime import timedelta
-
-from common import matrix
-
-
 SSH_MASTODON_CONN_ID = "ssh_mastodon"
 SSH_MONOLITH_CONN_ID = "ssh_monolith"
 
 MATRIX_WEBHOOK_CONN_ID = "matrix_webhook"
 MATRIX_WEBHOOK_API_KEY = "matrix_webhook_api_key"
-
-
-DEFAULT_DAG_ARGS = {
-    "catchup": False,
-    "owner": "techbloc",
-    "depends_on_past": False,
-    "email_on_failure": False,
-    "email_on_retry": False,
-    "retry_delay": timedelta(minutes=5),
-    "execution_timeout": timedelta(hours=1),
-    "on_failure_callback": matrix.on_failure_callback,
-}

--- a/techbloc_airflow/dags/constants.py
+++ b/techbloc_airflow/dags/constants.py
@@ -1,5 +1,22 @@
+from datetime import timedelta
+
+from common import matrix
+
+
 SSH_MASTODON_CONN_ID = "ssh_mastodon"
 SSH_MONOLITH_CONN_ID = "ssh_monolith"
 
 MATRIX_WEBHOOK_CONN_ID = "matrix_webhook"
 MATRIX_WEBHOOK_API_KEY = "matrix_webhook_api_key"
+
+
+DEFAULT_DAG_ARGS = {
+    "catchup": False,
+    "owner": "techbloc",
+    "depends_on_past": False,
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retry_delay": timedelta(minutes=5),
+    "execution_timeout": timedelta(hours=1),
+    "on_failure_callback": matrix.on_failure_callback,
+}

--- a/techbloc_airflow/dags/deployments/deployment_dags.py
+++ b/techbloc_airflow/dags/deployments/deployment_dags.py
@@ -5,6 +5,7 @@ import constants
 from airflow.decorators import dag
 from airflow.providers.http.operators.http import SimpleHttpOperator
 from airflow.providers.ssh.operators.ssh import SSHOperator
+from common import dag_utils
 
 
 SERVICES = [
@@ -22,9 +23,9 @@ for service in SERVICES:
     @dag(
         dag_id=dag_id,
         start_date=datetime(2022, 11, 24),
-        catchup=False,
         schedule=None,
         tags=["deployment"],
+        default_args=dag_utils.DEFAULT_DAG_ARGS,
     )
     def deployment_dag():
 

--- a/techbloc_airflow/dags/maintenance/mastodon/mastodon_cache_clear.py
+++ b/techbloc_airflow/dags/maintenance/mastodon/mastodon_cache_clear.py
@@ -13,6 +13,7 @@ DAYS_TO_KEEP = 14
     dag_id="mastodon_cache_clear",
     start_date=datetime(2022, 11, 10),
     schedule="@weekly",
+    catchup=False,
     tags=["maintenance", "mastodon"],
     default_args=dag_utils.DEFAULT_DAG_ARGS,
     doc_md=f"""

--- a/techbloc_airflow/dags/maintenance/mastodon/mastodon_cache_clear.py
+++ b/techbloc_airflow/dags/maintenance/mastodon/mastodon_cache_clear.py
@@ -3,6 +3,7 @@ from datetime import datetime
 import constants
 from airflow.decorators import dag
 from airflow.providers.ssh.operators.ssh import SSHOperator
+from common import dag_utils
 
 
 DAYS_TO_KEEP = 14
@@ -11,9 +12,9 @@ DAYS_TO_KEEP = 14
 @dag(
     dag_id="mastodon_cache_clear",
     start_date=datetime(2022, 11, 10),
-    catchup=False,
     schedule="@weekly",
     tags=["maintenance", "mastodon"],
+    default_args=dag_utils.DEFAULT_DAG_ARGS,
     doc_md=f"""
 # Clear Mastodon cache
 

--- a/tests/dags/common/test_matrix.py
+++ b/tests/dags/common/test_matrix.py
@@ -1,0 +1,36 @@
+from unittest import mock
+
+import pytest
+from airflow.exceptions import AirflowNotFoundException
+from common import matrix
+
+
+@pytest.mark.parametrize(
+    "environment, slack_message_override, expected_result",
+    [
+        # Dev
+        # Message is not sent by default. It is only sent if the override is enabled.
+        # Default
+        ("dev", False, False),
+        # Override is enabled
+        ("dev", True, True),
+        # Prod
+        # Message is sent by default; the override has no effect.
+        # Default
+        ("prod", False, True),
+        # Override enabled
+        ("prod", True, True),
+    ],
+)
+def test_should_send_message(environment, slack_message_override, expected_result):
+    with mock.patch("common.matrix.Variable") as MockVariable:
+        MockVariable.get.return_value = slack_message_override
+        assert matrix.should_send_message(environment) == expected_result
+
+
+@pytest.mark.parametrize("environment", ["dev", "prod"])
+def test_should_send_message_is_false_without_hook(environment):
+    with mock.patch("common.matrix.HttpHook") as HttpHookMock:
+        conn_mock = HttpHookMock.return_value.get_conn
+        conn_mock.side_effect = AirflowNotFoundException("nope")
+        assert not matrix.should_send_message(environment)


### PR DESCRIPTION
This PR adds an `on_failure_callback` which can be added to the DAGs via the `dag_utils.DAG_DEFAULT_ARGS`. This callback will run if a task within the DAG fails, and send an alert to Matrix. The `send_message` wrapper also has logic to skip sending a message when a DAG is run locally (with an option to be overridden for testing purposes).

**Example exception**:
![image](https://user-images.githubusercontent.com/10214785/204120407-156edd99-4c5f-4b99-8961-85464696899a.png)
