### PR TITLE
Set isort source paths

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,6 +39,7 @@ repos:
           - --use-parentheses
           - --ensure-newline-before-comments
           - --line-length=88
+          - --src=techbloc_airflow/dags
 
   - repo: https://github.com/pycqa/flake8
     rev: 3.9.2

--- a/techbloc_airflow/dags/common/matrix.py
+++ b/techbloc_airflow/dags/common/matrix.py
@@ -1,10 +1,11 @@
 import json
 import logging
 
-import constants
 from airflow.exceptions import AirflowNotFoundException
 from airflow.models import Variable
 from airflow.providers.http.hooks.http import HttpHook
+
+import constants
 
 
 log = logging.getLogger(__name__)

--- a/techbloc_airflow/dags/deployments/deployment_dags.py
+++ b/techbloc_airflow/dags/deployments/deployment_dags.py
@@ -3,9 +3,9 @@ from datetime import datetime
 from airflow.decorators import dag
 from airflow.operators.python import PythonOperator
 from airflow.providers.ssh.operators.ssh import SSHOperator
-from common import dag_utils, matrix
 
 import constants
+from common import dag_utils, matrix
 
 
 SERVICES = [

--- a/techbloc_airflow/dags/deployments/deployment_dags.py
+++ b/techbloc_airflow/dags/deployments/deployment_dags.py
@@ -1,10 +1,11 @@
 from datetime import datetime
 
-import constants
 from airflow.decorators import dag
 from airflow.operators.python import PythonOperator
 from airflow.providers.ssh.operators.ssh import SSHOperator
 from common import dag_utils, matrix
+
+import constants
 
 
 SERVICES = [

--- a/techbloc_airflow/dags/maintenance/backups/openoversight_backups.py
+++ b/techbloc_airflow/dags/maintenance/backups/openoversight_backups.py
@@ -1,8 +1,9 @@
 from datetime import datetime
 
-import constants
 from airflow.decorators import dag, task
 from airflow.providers.ssh.operators.ssh import SSHOperator
+
+import constants
 from common import dag_utils, matrix
 
 

--- a/techbloc_airflow/dags/maintenance/mastodon/backups/rotation_dag.py
+++ b/techbloc_airflow/dags/maintenance/mastodon/backups/rotation_dag.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 from typing import NamedTuple
 
-import constants
 from airflow.decorators import dag
 from airflow.operators.python import PythonOperator
 from airflow.providers.amazon.aws.operators.s3 import (
@@ -10,6 +9,8 @@ from airflow.providers.amazon.aws.operators.s3 import (
     S3ListOperator,
 )
 from airflow.utils.task_group import TaskGroup
+
+import constants
 from common import dag_utils, matrix
 from maintenance.mastodon.backups import rotation
 

--- a/techbloc_airflow/dags/maintenance/mastodon/mastodon_cache_clear.py
+++ b/techbloc_airflow/dags/maintenance/mastodon/mastodon_cache_clear.py
@@ -1,9 +1,10 @@
 from datetime import datetime
 
-import constants
 from airflow.decorators import dag
 from airflow.providers.ssh.operators.ssh import SSHOperator
 from common import dag_utils
+
+import constants
 
 
 DAYS_TO_KEEP = 14

--- a/techbloc_airflow/dags/maintenance/mastodon/mastodon_cache_clear.py
+++ b/techbloc_airflow/dags/maintenance/mastodon/mastodon_cache_clear.py
@@ -2,9 +2,9 @@ from datetime import datetime
 
 from airflow.decorators import dag
 from airflow.providers.ssh.operators.ssh import SSHOperator
-from common import dag_utils
 
 import constants
+from common import dag_utils
 
 
 DAYS_TO_KEEP = 14

--- a/tests/dags/common/test_matrix.py
+++ b/tests/dags/common/test_matrix.py
@@ -2,6 +2,7 @@ from unittest import mock
 
 import pytest
 from airflow.exceptions import AirflowNotFoundException
+
 from common import matrix
 
 

--- a/tests/dags/maintenance/mastodon/backups/test_rotation.py
+++ b/tests/dags/maintenance/mastodon/backups/test_rotation.py
@@ -1,4 +1,5 @@
 import pytest
+
 from maintenance.mastodon.backups import rotation
 
 

--- a/tests/dags/test_dag_parsing.py
+++ b/tests/dags/test_dag_parsing.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import pytest
 from airflow.models import DagBag
+
 from deployments.deployment_dags import SERVICES as DEPLOY_SERVICES
 
 


### PR DESCRIPTION
This PR sets the DAGs folder as an isort source path so that internal modules get treated as first party correctly.
