### PR TITLE
Add OpenOversight database backup DAG

### DIFF
--- a/techbloc_airflow/dags/maintenance/backups/openoversight_backups.py
+++ b/techbloc_airflow/dags/maintenance/backups/openoversight_backups.py
@@ -1,0 +1,53 @@
+from datetime import datetime
+
+import constants
+from airflow.decorators import dag, task
+from airflow.providers.ssh.operators.ssh import SSHOperator
+from common import dag_utils, matrix
+
+
+DAYS_TO_KEEP = 14
+
+
+@dag(
+    dag_id="openoversight_backup",
+    start_date=datetime(2022, 11, 10),
+    schedule="@weekly",
+    catchup=False,
+    tags=["maintenance", "mastodon"],
+    default_args=dag_utils.DEFAULT_DAG_ARGS,
+    doc_md="""
+# Backup OpenOversight database
+
+This DAG backs up the OpenOversight database using an existing `just` command on the
+instance.
+""",
+)
+def backup_openoversight():
+
+    backup = SSHOperator(
+        task_id="backup_openoversight",
+        ssh_conn_id=constants.SSH_MONOLITH_CONN_ID,
+        command="cd OpenOversight && just backup ~/backups/",
+    )
+
+    get_count = SSHOperator(
+        task_id="get_backup_count",
+        ssh_conn_id=constants.SSH_MONOLITH_CONN_ID,
+        do_xcom_push=True,
+        command="ls -l ~/backups/openoversight-postgres-*.tar.bz2 | wc -l",
+    )
+
+    @task
+    def notify_backup_count(count: bytes):
+        matrix.send_message(
+            f"OpenOversight backup complete! "
+            f"Total backups: `{count.decode('utf-8').strip()}`"
+        )
+
+    notify_backup_count(get_count.output)
+
+    backup >> get_count
+
+
+backup_openoversight()

--- a/techbloc_airflow/dags/maintenance/backups/openoversight_backups.py
+++ b/techbloc_airflow/dags/maintenance/backups/openoversight_backups.py
@@ -14,7 +14,7 @@ DAYS_TO_KEEP = 14
     start_date=datetime(2022, 11, 10),
     schedule="@weekly",
     catchup=False,
-    tags=["maintenance", "mastodon"],
+    tags=["maintenance", "openoversight", "backups"],
     default_args=dag_utils.DEFAULT_DAG_ARGS,
     doc_md="""
 # Backup OpenOversight database

--- a/tests/dags/test_dag_parsing.py
+++ b/tests/dags/test_dag_parsing.py
@@ -13,6 +13,7 @@ DAG_FOLDER = Path(__file__).parents[2] / "techbloc_airflow" / "dags"
 DAG_PATHS = [
     "deployments/deployment_dags.py",
     "maintenance/mastodon/mastodon_cache_clear.py",
+    "maintenance/backups/openoversight_backups.py",
 ]
 
 # Expected count from the DagBag once a file has been parsed


### PR DESCRIPTION
This PR adds a DAG which runs a weekly backup of the OpenOversight database and reports the number of backups to Matrix.


![image](https://user-images.githubusercontent.com/10214785/204207429-f1b9b315-1fda-4d42-a8b2-bc20937899e0.png)
