### PR TITLE
Handle the fact that S3 list pulls in recursive directories

### DIFF
--- a/techbloc_airflow/dags/maintenance/mastodon/backups/rotation.py
+++ b/techbloc_airflow/dags/maintenance/mastodon/backups/rotation.py
@@ -1,10 +1,19 @@
 from airflow.decorators import task
 
 
+def _filter_top_level(backups: list[str], top_level: bool) -> list[str]:
+    backups = sorted(backups, reverse=True)
+    # Only get actual files
+    backups = [backup for backup in backups if not backup.endswith("/")]
+    if top_level:
+        # Only get files from the top level prefix
+        backups = [backup for backup in backups if backup.count("/") == 1]
+    return backups
+
+
 @task()
 def get_most_recent_backup(backups: list[str]) -> str:
-    backups = sorted(backups, reverse=True)
-    backups = [backup for backup in backups if not backup.endswith("/")]
+    backups = _filter_top_level(backups, top_level=True)
     if not backups:
         raise ValueError("No backups found")
     # Return only the prefix itself
@@ -15,7 +24,7 @@ def get_most_recent_backup(backups: list[str]) -> str:
 def get_files_to_delete(
     backups: list[str],
     count: int,
+    top_level: bool = False,
 ) -> list[str]:
-    backups = sorted(backups, reverse=True)
-    backups = [backup for backup in backups if not backup.endswith("/")]
+    backups = _filter_top_level(backups, top_level=top_level)
     return backups[count:]

--- a/techbloc_airflow/dags/maintenance/mastodon/backups/rotation_dag.py
+++ b/techbloc_airflow/dags/maintenance/mastodon/backups/rotation_dag.py
@@ -60,9 +60,15 @@ for period in PERIODS:
                     prefix=prefix,
                 )
 
+                # The hourly runs will also include all backups recursively, so
+                # in non-hourly cases we'll need to filter those out
                 get_delete_files = rotation.get_files_to_delete.override(
                     task_id=f"get_files_to_delete_{service}"
-                )(list_period_keys.output, period.count)
+                )(
+                    backups=list_period_keys.output,
+                    count=period.count,
+                    top_level=period.name == "hourly",
+                )
 
                 delete_old_backups = S3DeleteObjectsOperator(
                     task_id=f"delete_old_backups_{service}",

--- a/tests/dags/maintenance/mastodon/backups/test_rotation.py
+++ b/tests/dags/maintenance/mastodon/backups/test_rotation.py
@@ -7,6 +7,8 @@ BACKUP_LIST = [
     "postgres/daily/",
     "postgres/weekly/",
     "postgres/",
+    "postgres/weekly/2022-11-26_06-00-01_backup.dump",
+    "postgres/daily/2022-11-26_06-00-01_backup.dump",
     "postgres/2022-11-25_19-00-01_backup.dump",
     "postgres/2022-11-25_20-00-01_backup.dump",
     "postgres/2022-11-25_21-00-01_backup.dump",
@@ -31,6 +33,17 @@ BACKUP_LIST = [
     "postgres/2022-11-26_16-00-01_backup.dump",
     "postgres/2022-11-26_17-00-01_backup.dump",
 ]
+
+
+@pytest.mark.parametrize(
+    "backups, top_level, expected",
+    [
+        (BACKUP_LIST, True, BACKUP_LIST[5:]),
+        (BACKUP_LIST, False, BACKUP_LIST[3:]),
+    ],
+)
+def test_filter_top_level(backups, top_level, expected):
+    assert set(rotation._filter_top_level(backups, top_level)) == set(expected)
 
 
 @pytest.mark.parametrize(
@@ -61,17 +74,17 @@ def test_get_most_recent_backup(backups, expected):
     "backups, count, expected",
     [
         # Keep one
-        (BACKUP_LIST, 1, BACKUP_LIST[3:-1]),
+        (BACKUP_LIST, 1, BACKUP_LIST[5:-1]),
         # Keep several, should be last few
-        (BACKUP_LIST, 5, BACKUP_LIST[3:-5]),
+        (BACKUP_LIST, 5, BACKUP_LIST[5:-5]),
         # Keep all
         (BACKUP_LIST, len(BACKUP_LIST), []),
         # Emtpy input list
         ([], 10, []),
         # Don't keep any
-        (BACKUP_LIST, 0, BACKUP_LIST[3:]),
+        (BACKUP_LIST, 0, BACKUP_LIST[5:]),
     ],
 )
 def test_get_files_to_delete(backups, count, expected):
-    actual = rotation.get_files_to_delete.function(backups, count)
+    actual = rotation.get_files_to_delete.function(backups, count, True)
     assert set(actual) == set(expected)


### PR DESCRIPTION
This PR addresses an issue we found wherein the `S3ListOperator` pulls down _all_ files in recursive directories too, not just at the level the prefix is specified.

This adds logic to filter down to _only_ the top level files in cases where the most recent hourly backup is being copied.
