### PR TITLE
Add mastodon stack restart DAG

### DIFF
--- a/techbloc_airflow/dags/maintenance/mastodon/mastodon_stack_restart.py
+++ b/techbloc_airflow/dags/maintenance/mastodon/mastodon_stack_restart.py
@@ -1,0 +1,37 @@
+"""
+# Restart Mastodon stack
+
+The Mastodon stack generates a ton of logs, which can quickly
+overwhelm the local disk and fill up space. It's healthy practice
+to restart the stack once a week to counteract this. Ideally this
+would also be paired with a change to Docker's log retention
+for the service as well.
+"""
+from datetime import datetime
+
+from airflow.decorators import dag
+from airflow.providers.ssh.operators.ssh import SSHOperator
+
+import constants
+from common import dag_utils
+
+
+@dag(
+    dag_id="mastodon_stack_restart",
+    start_date=datetime(2023, 3, 1),
+    schedule="@weekly",
+    tags=["maintenance", "mastodon"],
+    default_args=dag_utils.DEFAULT_DAG_ARGS,
+    catchup=False,
+    doc_md=__doc__,
+)
+def restart_stack():
+
+    SSHOperator(
+        task_id="restart_stack",
+        ssh_conn_id=constants.SSH_MASTODON_CONN_ID,
+        command="cd mastodon && docker-compose down && docker-compose up -d",
+    )
+
+
+restart_stack()


### PR DESCRIPTION
Quick PR for a Mastodon restart DAG. The local disk filled up recently (to the point where I couldn't even run `docker-compose down` until I deleted something lol). I'd rather prevent this by running this weekly. Should be followed up by a PR to change log retention policy in docker-compose, but that will take more time since I'm not sure how to do that. 
