### PR TITLE
Use "docker compose" over "docker-compose"

### DIFF
--- a/justfile
+++ b/justfile
@@ -44,7 +44,7 @@ dotenv:
 
 # Run docker compose with the specified command
 _dc *args:
-    docker-compose {{ DOCKER_FILES }} {{ args }}
+    docker compose {{ DOCKER_FILES }} {{ args }}
 
 # Build all (or specified) container(s)
 build service="": dotenv


### PR DESCRIPTION
`docker-compose` is not available on the newer versions of docker, but `docker compose` is. 
