### PR TITLE
Move remote logging from docker image into environment settings

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -22,6 +22,10 @@ AIRFLOW__WEBSERVER__SECRET_KEY=sample-secret-key=
 AIRFLOW__CORE__EXECUTOR=LocalExecutor
 # Environment this instance is being run in
 AIRFLOW_VAR_ENVIRONMENT=dev
+# Logging settings
+AIRFLOW__LOGGING__REMOTE_LOGGING=True
+AIRFLOW__LOGGING__REMOTE_LOG_CONN_ID=aws_default
+AIRFLOW__LOGGING__REMOTE_BASE_LOG_FOLDER=s3://techbloc-airflow-logs
 
 ########################################################################################
 # Connection/Variable info
@@ -31,7 +35,7 @@ AIRFLOW_VAR_ENVIRONMENT=dev
 AIRFLOW__DATABASE__SQL_ALCHEMY_CONN=postgresql+psycopg2://airflow:airflow@postgres:5432/airflow
 # Remote logging connection ID
 # Replace "access_key" and "secret+key" with the real values. Secret key must be URL-encoded
-AIRFLOW_CONN_AWS_DEFAULT=aws://test_key:test_secret@?region_name=us-east-1&endpoint_url=http://s3:5000
+AIRFLOW_CONN_AWS_DEFAULT=aws://test_key:test_secret@?region_name=us-east-1&endpoint_url=http%3A%2F%2Fs3%3A5000
 
 # SSH connections
 AIRFLOW_CONN_SSH_MONOLITH=ssh://user@service

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,11 +25,6 @@ ENV AIRFLOW__CORE__LOAD_EXAMPLES=False
 ENV AIRFLOW__CORE__LOAD_DEFAULT_CONNECTIONS=False
 ENV AIRFLOW__CORE__ENABLE_XCOM_PICKLING=True
 
-# TODO: Test if moving this to .env changes anything!
-ENV AIRFLOW__LOGGING__REMOTE_LOGGING=True
-ENV AIRFLOW__LOGGING__REMOTE_LOG_CONN_ID=aws_default
-ENV AIRFLOW__LOGGING__REMOTE_BASE_LOG_FOLDER=s3://techbloc-airflow-logs
-
 
 USER root
 RUN apt-get update && apt-get -yqq install \


### PR DESCRIPTION
This is a follow up to #66, these settings need to be overridden in production anyway (at least one of them) so it's easier not to define them in the docker image. This also corrects the `aws_default` hook to correctly URL encode the `endpoint_url` extra argument, which was causing logging to fail previously.
