### PR TITLE
Remove outdated version specifier in docker-compose

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,6 +1,3 @@
-version: '3'
-
-
 # Common build configuration for Airflow
 # Extension field, see https://docs.docker.com/compose/compose-file/compose-file-v3/#extension-fields
 x-airflow-common:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
 
   caddy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   postgres:
     image: postgres:13


### PR DESCRIPTION
We were receiving this warning when running docker commands:

```bash
$ j down
docker compose --file=docker-compose.yml --file=docker-compose.dev.yml down
WARN[0000] /home/madison/git/techbloc-airflow/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
WARN[0000] /home/madison/git/techbloc-airflow/docker-compose.dev.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
```

This prevents these errors from arising. 
