### PR TITLE
New DAG: offsite backups for docker volumes

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -44,7 +44,7 @@ AIRFLOW_CONN_MATRIX_WEBHOOK=https://matrix-webhook
 AIRFLOW_VAR_MATRIX_WEBHOOK_API_KEY=api_key
 
 S3_LOCAL_ENDPOINT=http://s3:5000
-AWS_CONN_ID=aws_default
+SPACES_CONN_ID=aws_default
 
 ########################################################################################
 # Other config

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,8 @@ RUN apt-get update && apt-get -yqq install \
     libpq-dev \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*
-RUN mkdir -p ${DATABASE_DIR} /home/airflow/.ipython/ /opt/ssh/ && \
-    chown -R airflow ${DATABASE_DIR} /home/airflow/.ipython/ /opt/ssh/
+RUN mkdir -p ${DATABASE_DIR} /home/airflow/.ipython/ /opt/ssh/ /opt/backups && \
+    chown -R airflow ${DATABASE_DIR} /home/airflow/.ipython/ /opt/ssh/ /opt/backups
 USER airflow
 
 WORKDIR  ${AIRFLOW_HOME}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -32,7 +32,7 @@ services:
       MINIO_ROOT_USER: ${AWS_ACCESS_KEY}
       MINIO_ROOT_PASSWORD: ${AWS_SECRET_KEY}
       # Comma separated list of buckets to create on startup
-      BUCKETS_TO_CREATE: spd-lookup,airflow,techbloc-airflow-logs
+      BUCKETS_TO_CREATE: spd-lookup,airflow,techbloc-airflow-logs,monolith-backups
     # Create empty buckets on every container startup
     # Note: $0 is included in the exec because "/bin/bash -c" swallows the first
     # argument, so it must be re-added at the beginning of the exec call

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,3 +1,10 @@
+# https://docs.docker.com/reference/compose-file/extension/
+x-mounts: &mounts
+  volumes:
+    - /home/techbloc/.ssh:/opt/ssh
+    - /home/techbloc/backups:/opt/backups
+
+
 services:
 
   caddy:
@@ -12,12 +19,10 @@ services:
       - caddy_config:/config
 
   scheduler:
-    volumes:
-      - /home/techbloc/.ssh:/opt/ssh
+    <<: *mounts
 
   webserver:
-    volumes:
-      - /home/techbloc/.ssh:/opt/ssh
+    <<: *mounts
 
 volumes:
   caddy_data:

--- a/techbloc_airflow/dags/common/matrix.py
+++ b/techbloc_airflow/dags/common/matrix.py
@@ -29,7 +29,7 @@ def should_send_message(
 
     # Exit early if we aren't on production or if force alert is not set
     force_message = Variable.get(
-        "SLACK_MESSAGE_OVERRIDE", default_var=False, deserialize_json=True
+        "MATRIX_MESSAGE_OVERRIDE", default_var=False, deserialize_json=True
     )
     return environment == "prod" or force_message
 

--- a/techbloc_airflow/dags/constants.py
+++ b/techbloc_airflow/dags/constants.py
@@ -1,4 +1,8 @@
+import os
+
+
 SSH_MONOLITH_CONN_ID = "ssh_monolith"
+SPACES_CONN_ID = os.getenv("SPACES_CONN_ID")
 
 MATRIX_WEBHOOK_CONN_ID = "matrix_webhook"
 MATRIX_WEBHOOK_API_KEY = "matrix_webhook_api_key"

--- a/techbloc_airflow/dags/maintenance/backups/offsite_backups.py
+++ b/techbloc_airflow/dags/maintenance/backups/offsite_backups.py
@@ -73,7 +73,7 @@ def backup_service(config: OffsiteConfig):
     doc_md="""
 # Backup volume offsite
 
-This DAG backs up a Docker volume using 
+This DAG backs up a Docker volume using
 [loomchild/volume-backup](https://github.com/loomchild/volume-backup).
 It then copies the backup to the local machine, then uploads it to Spaces.
 """,

--- a/techbloc_airflow/dags/maintenance/backups/offsite_backups.py
+++ b/techbloc_airflow/dags/maintenance/backups/offsite_backups.py
@@ -10,7 +10,6 @@ from airflow.utils.trigger_rule import TriggerRule
 
 import constants
 from common import dag_utils, matrix
-
 from maintenance.backups.offsite_configs import OFFSITE_CONFIGS, OffsiteConfig
 
 

--- a/techbloc_airflow/dags/maintenance/backups/offsite_backups.py
+++ b/techbloc_airflow/dags/maintenance/backups/offsite_backups.py
@@ -1,0 +1,72 @@
+from datetime import datetime
+
+from airflow.decorators import dag, task, task_group
+from airflow.operators.bash import BashOperator
+from airflow.providers.amazon.aws.transfers.local_to_s3 import (
+    LocalFilesystemToS3Operator,
+)
+from airflow.providers.ssh.operators.ssh import SSHOperator
+
+import constants
+from common import dag_utils, matrix
+
+from offsite_configs import OFFSITE_CONFIGS, OffsiteConfig
+
+
+LOCAL_BACKUPS_FOLDER = "/opt/backups"
+BUCKET_NAME = "monolith-backups"
+
+
+@task_group
+def backup_service(config: OffsiteConfig):
+    local_backup = f"{LOCAL_BACKUPS_FOLDER}/{config.filename}"
+
+    backup = SSHOperator(
+        task_id=f"backup_{config.name}",
+        ssh_conn_id=constants.SSH_MONOLITH_CONN_ID,
+        command=config.command,
+    )
+
+    copy_to_local = BashOperator(
+        task_id=f"copy_{config.name}_to_local",
+        bash_command=f"scp monolith:{config.final_path} {local_backup}",
+    )
+
+    copy_to_spaces = LocalFilesystemToS3Operator(
+        task_id=f"copy_local_{config.name}_to_spaces",
+        aws_conn_id=constants.SPACES_CONN_ID,
+        dest_bucket=BUCKET_NAME,
+        dest_key=config.filename,
+        replace=True,
+        filename=local_backup,
+    )
+
+    @task
+    def notify_backup_complete():
+        matrix.send_message(
+            f"{config.name} backup complete at: `s3://{BUCKET_NAME}/{config.filename}`"
+        )
+
+    backup >> copy_to_local >> copy_to_spaces >> notify_backup_complete()
+
+
+@dag(
+    dag_id="offsite_backup",
+    start_date=datetime(2025, 3, 15),
+    schedule="0 3 * * 0",
+    catchup=False,
+    tags=["maintenance", "matrix", "openoversight", "backups"],
+    default_args=dag_utils.DEFAULT_DAG_ARGS,
+    doc_md="""
+# Backup volume offsite
+
+This DAG backs up a Docker volume using [loomchild/volume-backup](https://github.com/loomchild/volume-backup).
+It then copies the backup to the local machine, then uploads it to Spaces.
+""",
+)
+def backup_matrix():
+    for config in OFFSITE_CONFIGS:
+        backup_service(config)
+
+
+backup_matrix()

--- a/techbloc_airflow/dags/maintenance/backups/offsite_backups.py
+++ b/techbloc_airflow/dags/maintenance/backups/offsite_backups.py
@@ -73,7 +73,8 @@ def backup_service(config: OffsiteConfig):
     doc_md="""
 # Backup volume offsite
 
-This DAG backs up a Docker volume using [loomchild/volume-backup](https://github.com/loomchild/volume-backup).
+This DAG backs up a Docker volume using 
+[loomchild/volume-backup](https://github.com/loomchild/volume-backup).
 It then copies the backup to the local machine, then uploads it to Spaces.
 """,
 )

--- a/techbloc_airflow/dags/maintenance/backups/offsite_backups.py
+++ b/techbloc_airflow/dags/maintenance/backups/offsite_backups.py
@@ -10,7 +10,7 @@ from airflow.providers.ssh.operators.ssh import SSHOperator
 import constants
 from common import dag_utils, matrix
 
-from offsite_configs import OFFSITE_CONFIGS, OffsiteConfig
+from maintenance.backups.offsite_configs import OFFSITE_CONFIGS, OffsiteConfig
 
 
 LOCAL_BACKUPS_FOLDER = "/opt/backups"
@@ -66,7 +66,7 @@ It then copies the backup to the local machine, then uploads it to Spaces.
 )
 def backup_matrix():
     for config in OFFSITE_CONFIGS:
-        backup_service(config)
+        backup_service.override(group_id=f"backup_service_{config.name}")(config)
 
 
 backup_matrix()

--- a/techbloc_airflow/dags/maintenance/backups/offsite_configs.py
+++ b/techbloc_airflow/dags/maintenance/backups/offsite_configs.py
@@ -1,0 +1,40 @@
+from dataclasses import dataclass, field
+from textwrap import dedent
+
+
+@dataclass
+class OffsiteConfig:
+    name: str
+    folder: str
+    volume: str
+    backup_folder: str = "~/backups"
+
+    filename: str = field(init=False)
+    final_path: str = field(init=False)
+    command: str = field(init=False)
+
+    def __post_init__(self):
+        self.filename = f"{self.name}-backup.tar.bz2"
+        self.final_path = f"{self.backup_folder}/{self.filename}"
+        self.command = dedent(f"""
+        cd {self.folder} && \
+        docker run --rm \
+            -v {self.volume}:/volume \
+            -v {self.backup_folder}:/backup \
+            loomchild/volume-backup \
+            backup {self.filename}
+        """)
+
+
+OFFSITE_CONFIGS = [
+    OffsiteConfig(
+        name="matrix",
+        folder="synapse",
+        volume="synapse_synapse_pg_data",
+    ),
+    OffsiteConfig(
+        name="openoversight",
+        folder="OpenOversight",
+        volume="openoversight_postgres",
+    ),
+]

--- a/techbloc_airflow/dags/maintenance/backups/offsite_configs.py
+++ b/techbloc_airflow/dags/maintenance/backups/offsite_configs.py
@@ -16,7 +16,8 @@ class OffsiteConfig:
     def __post_init__(self):
         self.filename = f"{self.name}-backup.tar.bz2"
         self.final_path = f"{self.backup_folder}/{self.filename}"
-        self.command = dedent(f"""
+        self.command = dedent(
+            f"""
         cd {self.folder} && \
         just down && \
         docker run --rm \
@@ -25,7 +26,8 @@ class OffsiteConfig:
             loomchild/volume-backup \
             backup {self.filename} && \
         just up
-        """)
+        """
+        )
 
 
 OFFSITE_CONFIGS = [

--- a/techbloc_airflow/dags/maintenance/backups/offsite_configs.py
+++ b/techbloc_airflow/dags/maintenance/backups/offsite_configs.py
@@ -18,11 +18,13 @@ class OffsiteConfig:
         self.final_path = f"{self.backup_folder}/{self.filename}"
         self.command = dedent(f"""
         cd {self.folder} && \
+        just down && \
         docker run --rm \
             -v {self.volume}:/volume \
             -v {self.backup_folder}:/backup \
             loomchild/volume-backup \
-            backup {self.filename}
+            backup {self.filename} && \
+        just up
         """)
 
 


### PR DESCRIPTION
This PR adds a new DAG for offsite backups of various services. The backup is performed by taking a snapshot of the volume that houses the critical data, in most cases this is a Postgres volume or similar.

This DAG will copy the created file to the Airflow instance, then upload it to DO Spaces. Other, external services will then pull these files regularly to ensure we have backups that exist outside of our current infra.

Example with both a successful run and a failed run:
![image](https://github.com/user-attachments/assets/21aa383e-f887-413b-8060-30277aafdf8f)

