### PR TITLE
Add retries to backup notify task since matrix will be down

### DIFF
--- a/techbloc_airflow/dags/maintenance/backups/offsite_backups.py
+++ b/techbloc_airflow/dags/maintenance/backups/offsite_backups.py
@@ -40,7 +40,7 @@ def backup_service(config: OffsiteConfig):
         filename=local_backup,
     )
 
-    @task
+    @task(retries=3, retry_exponential_backoff=True)
     def notify_backup_complete():
         matrix.send_message(
             f"{config.name} backup complete at: `s3://{BUCKET_NAME}/{config.filename}`"


### PR DESCRIPTION
Since the server itself will be down I wouldn't be surprised if this tasks fails. So adding in some retries here.
