### PR TITLE
Allow setting a common bucket for the environment

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -45,6 +45,8 @@ AIRFLOW_VAR_MATRIX_WEBHOOK_API_KEY=api_key
 
 S3_LOCAL_ENDPOINT=http://s3:5000
 SPACES_CONN_ID=aws_default
+# Optional bucket to use, necessary prefix in all cases for DigitalOcean Spaces
+# SPACES_BUCKET_NAME=bucketname
 
 ########################################################################################
 # Other config

--- a/techbloc_airflow/dags/constants.py
+++ b/techbloc_airflow/dags/constants.py
@@ -3,6 +3,11 @@ import os
 
 SSH_MONOLITH_CONN_ID = "ssh_monolith"
 SPACES_CONN_ID = os.getenv("SPACES_CONN_ID")
+SPACES_BUCKET_NAME = os.getenv("SPACES_BUCKET_NAME", "")
+# DigitalOcean Spaces has a common shared bucket for everything, whereas locally we
+# have a separate bucket for each service. If the bucket name is defined, all keys
+# will be prefixed with that.
+SPACES_KEY_PREFIX = f"s3://{SPACES_BUCKET_NAME}/" if SPACES_BUCKET_NAME else "s3://"
 
 MATRIX_WEBHOOK_CONN_ID = "matrix_webhook"
 MATRIX_WEBHOOK_API_KEY = "matrix_webhook_api_key"


### PR DESCRIPTION
After being deployed, the DAG was failing with the following error:

```
boto3.exceptions.S3UploadFailedError: Failed to upload /opt/backups/openoversight-backup.tar.bz2 to monolith-backups/openoversight-backup.tar.bz2: An error occurred (NoSuchBucket) when calling the CreateMultipartUpload operation: None
```

This is due to a nuance in how DigitalOcean Spaces works - each "space" is actually a separate bucket, and everything else is just prefixes under it. Rather than try and align this mapping locally, it's easier for now to set this up to prefix keys with that bucket name in cases where it's defined. Eventually it'd be nice to align on that but I'll have a follow-up PR for it. 

I've tested the new key URL for transferring both locally and in prod, and it works!
