### PR TITLE
⬆ Upgrade Airflow from 2.10.0 to 2.10.5

### DIFF
--- a/requirements_prod.txt
+++ b/requirements_prod.txt
@@ -1,2 +1,2 @@
 # PYTHON=3.12
-apache-airflow[amazon,postgres,http,ssh]==2.10.0
+apache-airflow[amazon,postgres,http,ssh]==2.10.5


### PR DESCRIPTION
Dependabot seems to think that this version is up to date (see #85). It's not! This upgrades our Airflow cluster to 2.10.5.
