### PR TITLE
✨ Add sea-scanners-wiki to deployable services

### DIFF
--- a/techbloc_airflow/dags/deployments/deployment_dags.py
+++ b/techbloc_airflow/dags/deployments/deployment_dags.py
@@ -14,6 +14,7 @@ SERVICES = [
     "OpenOversight",
     "spd-lookup",
     "bookmarkbot",
+    "sea-scanners-wiki",
 ]
 
 
@@ -29,7 +30,6 @@ for service in SERVICES:
         default_args=dag_utils.DEFAULT_DAG_ARGS,
     )
     def deployment_dag():
-
         ssh_deploy = SSHOperator(
             task_id=f"deploy_{service_name}",
             ssh_conn_id=constants.SSH_MONOLITH_CONN_ID,


### PR DESCRIPTION
This used to be able to be upgraded within the wiki UI (by using a sidecar container), but a Docker upgrade broke that particular functionality. I've been doing this manually since then, but there's nothing special about the process for upgrading this service. So I added a `justfile` to the folder and now it can be deployed just like our other services!

I tested this by running the DAG locally.
